### PR TITLE
Add Hacktoberfest 2022 page

### DIFF
--- a/Hacktoberfest-2022.md
+++ b/Hacktoberfest-2022.md
@@ -8,18 +8,18 @@ If you’d like to see what Oppia does, download our [Android app](https://play.
 
 Please follow these steps to get started:
 
-1. [Sign up](https://hacktoberfest.com/register/) to register for Hacktoberfest
-2. [Set up your local environment](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#setting-things-up) to contribute to Oppia
+1. [Sign up](https://hacktoberfest.com/register/) to register for Hacktoberfest.
+2. [Set up your local environment](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#setting-things-up) to contribute to Oppia.
 3. Find a "good first issue" to work on (see [here](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#finding-something-to-do) and [here](https://github.com/oppia/oppia/issues?q=is%3Aopen+is%3Aissue+label%3AHacktoberfest+no%3Aassignee)).
-4. Fix the issue by creating some changes and sending a pull request for review, following our [PR instructions](https://github.com/oppia/oppia/wiki/Make-a-pull-request)
-5. Go through the code review process until you receive approval and the PR gets merged
+4. Fix the issue by creating some changes and sending a pull request for review, following our [PR instructions](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
+5. Go through the code review process until you receive approval and the PR gets merged.
 6. To earn a t-shirt: repeat until you've submitted at least 4 pull requests!
 
 ## For non-code contributors
 
 If you’re not a coder, don’t worry! This year, Hacktoberfest is introducing a [low/non-code contribution option](https://hacktoberfest.com/about/#low-or-non-code), so you can still participate, and there are lots of opportunities to do so :)
 
-We have a lot of non-code-contribution opportunities available, including giving talks, organizing case studies, translating, illustrations, graphic design and creating practice questions. To learn more about these opportunities, please check out our hacktoberfest-2022-non-code-contributions GitHub repo and its issue tracker!
+We have a lot of non-code-contribution opportunities available, including giving talks, organizing case studies, translating, illustrations, graphic design and creating practice questions. To learn more about these opportunities, please check out our [hacktoberfest-2022-non-code-contributions GitHub repo](https://github.com/oppia/hacktoberfest-2022-non-code-contributions) and its [issue tracker](https://github.com/oppia/hacktoberfest-2022-non-code-contributions/issues)!
 
 ## Donations
 

--- a/Hacktoberfest-2022.md
+++ b/Hacktoberfest-2022.md
@@ -1,0 +1,45 @@
+Oppia is excited to be joining the rest of the GitHub community in participating in this year's [Hacktoberfest](https://hacktoberfest.digitalocean.com/). This is an event where contributors will receive a free Hacktoberfest 2022 t-shirt if they submit at least 4 valid pull requests to any GitHub-hosted repository in the month of October.
+
+If you have any questions, feel free to ask them on [GitHub Discussions](https://github.com/oppia/oppia/discussions).
+
+If you’d like to see what Oppia does, download our [Android app](https://play.google.com/store/apps/details?id=org.oppia.android) or check out our math lessons at [https://www.oppia.org/learn/math](https://www.oppia.org/learn/math)! You can also read more about our mission [here](https://github.com/oppia/oppia/wiki/Oppia's-Mission).
+
+## Getting Started
+
+Please follow these steps to get started:
+
+1. [Sign up](https://hacktoberfest.com/register/) to register for Hacktoberfest
+2. [Set up your local environment](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#setting-things-up) to contribute to Oppia
+3. Find a "good first issue" to work on (see [here](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#finding-something-to-do) and [here](https://github.com/oppia/oppia/issues?q=is%3Aopen+is%3Aissue+label%3AHacktoberfest+no%3Aassignee)).
+4. Fix the issue by creating some changes and sending a pull request for review, following our [PR instructions](https://github.com/oppia/oppia/wiki/Make-a-pull-request)
+5. Go through the code review process until you receive approval and the PR gets merged
+6. To earn a t-shirt: repeat until you've submitted at least 4 pull requests!
+
+## For non-code contributors
+
+If you’re not a coder, don’t worry! This year, Hacktoberfest is introducing a [low/non-code contribution option](https://hacktoberfest.com/about/#low-or-non-code), so you can still participate, and there are lots of opportunities to do so :)
+
+We have a lot of non-code-contribution opportunities available, including giving talks, organizing case studies, translating, illustrations, graphic design and creating practice questions. To learn more about these opportunities, please check out our hacktoberfest-2022-non-code-contributions GitHub repo and its issue tracker!
+
+## Donations
+
+You can also support the Oppia open source project through donations! Please see the [Hacktoberfest page](https://hacktoberfest.com/donate/) or our [GitHub Sponsors](https://github.com/sponsors/oppia) page for more information. We truly appreciate your support!
+
+
+## FAQ
+
+**Q: What is Hacktoberfest?**
+
+A: Hacktoberfest is an annual event across all of GitHub which is meant to encourage developers to contribute to open source projects.
+
+**Q: Must we only work on issues marked with the Hacktoberfest label?**
+
+A: Not necessarily! **Any** pull request will count toward your 4, even if you are fixing an issue that doesn't have the Hacktoberfest label. Issues with the Hacktoberfest label are just meant to provide some starter ideas for newcomers. Feel free to browse issues in our different [team project boards](https://github.com/oppia/oppia/projects?query=is%3Aopen) to see if there is something you’d like to work on.
+
+**Q: Do pull requests need to have the Hacktoberfest label to count?**
+
+A: Nope! No information from GitHub, Digital Ocean, and Dev seems to indicate that this is necessary.
+
+**Q: Do I need to mention that I am participating in Hacktoberfest when I open my PR?**
+
+A: No, but if you mention in your PR description that you are participating in Hacktoberfest, we *might* be able to add the "hacktoberfest-accepted" label if your PR looks good but doesn't get through the full review process before the end of October. That said, we prefer that PRs get fully merged, so we recommend starting early!

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -10,7 +10,7 @@
     * [[Designers and artists|Contributing-to-Oppia's-design]]
   * **[[Outreachy Dec 2021 to Mar 2022|Outreachy-Dec-2021-to-Mar-2022]]**
   * **[[Google Summer of Code 2022|Google-Summer-of-Code-2022]]**
-
+  * **[Hacktoberfest 2022|Hacktoberfest-2022]]**
 ---
 **Developing Oppia**
   * [[FAQs|Frequently-Asked-Questions]]

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -8,9 +8,9 @@
     * [[UX researchers|Conducting-research-with-students]]
     * [[Voice artists | Instructions-for-voice-artists]]
     * [[Designers and artists|Contributing-to-Oppia's-design]]
+  * **[Hacktoberfest 2022|Hacktoberfest-2022]]**
   * **[[Outreachy Dec 2021 to Mar 2022|Outreachy-Dec-2021-to-Mar-2022]]**
   * **[[Google Summer of Code 2022|Google-Summer-of-Code-2022]]**
-  * **[Hacktoberfest 2022|Hacktoberfest-2022]]**
 ---
 **Developing Oppia**
   * [[FAQs|Frequently-Asked-Questions]]

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -135,6 +135,7 @@
     * GHC Open Source Day: [[2019|GHC-Open-Source-Day-2019]], [[2018|GHC-Open-Source-Day]]
     * Season of Docs: [[2019|Season-of-Docs-2019]]
     * DSC-SLoP (Semester Long Project): [[2020|SLoP-2020]]
+    * Outreachy: [[Dec 2021 to Mar 2022|Outreachy-Dec-2021-to-Mar-2022]]
 ---
 **Fun**
 * [Events Team](https://github.com/oppia/oppia/wiki/Events-Team)

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -9,7 +9,6 @@
     * [[Voice artists | Instructions-for-voice-artists]]
     * [[Designers and artists|Contributing-to-Oppia's-design]]
   * **[Hacktoberfest 2022|Hacktoberfest-2022]]**
-  * **[[Outreachy Dec 2021 to Mar 2022|Outreachy-Dec-2021-to-Mar-2022]]**
   * **[[Google Summer of Code 2022|Google-Summer-of-Code-2022]]**
 ---
 **Developing Oppia**


### PR DESCRIPTION
Hacktoberfest-2022 wiki page has been added and the sidebar has been updated to include the link to the wiki.

You can see the wiki page render [here](https://github.com/gp201/oppia-web-developer-docs/blob/Hacktoberfest-2022/Hacktoberfest-2022.md) 