### PR TITLE
Reorder the 'codebase overview' links and put a pointer to them.

### DIFF
--- a/Contributing-code-to-Oppia.md
+++ b/Contributing-code-to-Oppia.md
@@ -53,6 +53,8 @@ If you run into any problems along the way, we're here to help! Check out our [[
 
 See our [[page of learning resources|Learning-Resources]] for suggestions on how you can improve your development skills. When you take up an issue that requires programming languages or tools you are unfamiliar with, check out that page for resources that other developers have found useful when learning.
 
+We also **strongly recommend** taking a look through the resources under "Developing Oppia" in the wiki sidebar. Good places to start include the [[Overview of the Oppia codebase|Overview-of-the-Oppia-codebase]] and the [[tips on how to find the right code to change|Find-the-right-code-to-change]].
+
 ## Finding something to do
 
 ### Starter projects for new contributors

--- a/Contributing-code-to-Oppia.md
+++ b/Contributing-code-to-Oppia.md
@@ -53,7 +53,7 @@ If you run into any problems along the way, we're here to help! Check out our [[
 
 See our [[page of learning resources|Learning-Resources]] for suggestions on how you can improve your development skills. When you take up an issue that requires programming languages or tools you are unfamiliar with, check out that page for resources that other developers have found useful when learning.
 
-We also **strongly recommend** taking a look through the resources under "Developing Oppia" in the wiki sidebar. Good places to start include the [[Overview of the Oppia codebase|Overview-of-the-Oppia-codebase]] and the [[tips on how to find the right code to change|Find-the-right-code-to-change]].
+We also **strongly recommend** looking through the resources under "Developing Oppia" in the wiki sidebar. Good places to start include the [[Overview of the Oppia codebase|Overview-of-the-Oppia-codebase]] and the [[tips on how to find the right code to change|Find-the-right-code-to-change]].
 
 ## Finding something to do
 

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -23,11 +23,11 @@
   * [[Git cheat sheet|Git-cheat-sheet]]
   * [[Codebase Overview|Overview-of-the-Oppia-codebase]]
     * [[Glossary of terms|Glossary-of-terms]]
-    * [[Apache Beam Jobs|Apache-beam-jobs]]
+    * [[Tips for finding the right code to change|Find-the-right-code-to-change]]
     * [[Tips for analyzing the codebase|Analyzing-the-codebase]]
     * [[Tour of Oppia webpages|How-to-access-Oppia-webpages]]
-    * [[How to find the right code to change|Find-the-right-code-to-change]]
     * [User documentation](https://oppia.github.io/)
+    * [[Apache Beam Jobs|Apache-beam-jobs]]
   * [[List of current projects|https://github.com/oppia/oppia/projects]]
   * **[[Good first issues|https://github.com/oppia/oppia/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22]]**
   * Coding Guidelines


### PR DESCRIPTION
This PR moves a couple of links around so that the codebase overview is arranged in order of priority. It also adds a more explicit pointer to the "how to find the right code to edit" doc.