### PR TITLE
Fix #44: Rename lib1g-dev to zlib1g-dev

### DIFF
--- a/Installing-Oppia-(Linux;-Python-3).md
+++ b/Installing-Oppia-(Linux;-Python-3).md
@@ -92,7 +92,7 @@ For your virtual environment, we recommend you use [pyenv](https://github.com/py
     sudo apt-get install make
     sudo apt-get install build-essential
     sudo apt-get install libssl-dev
-    sudo apt-get install lib1g-dev
+    sudo apt-get install zlib1g-dev
     sudo apt-get install libbz2-dev
     sudo apt-get install libreadline-dev
     sudo apt-get install libsqlite3-dev


### PR DESCRIPTION
Fixes #44: Rename library `lib1g-dev` to `zlib1g-dev`, this is because the naming changed in linux. 

https://github.com/oppia/oppia/pull/16367