### PR TITLE
Fix #92: Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Created .gitignore file for "[oppia-web-developer-docs](https://github.com/oppia/oppia-web-developer-docs)" repository and included necessary file to be ignored.

Will add more files if found necessary to add.