### PR TITLE
Make it clearer how to choose an issue. Other minor changes.

### DIFF
--- a/Contributing-code-to-Oppia.md
+++ b/Contributing-code-to-Oppia.md
@@ -65,7 +65,7 @@ Welcome! Please make sure to follow the instructions above if you haven't alread
 
 After that, you can choose a good first issue from the [list of good first issues](https://github.com/oppia/oppia/labels/good%20first%20issue). These issues are hand-picked to ensure that you don't run into unexpected roadblocks while working on them, and each of them should have clear instructions for new contributors. If you see one that doesn't, please let us know via [GitHub Discussions](https://github.com/oppia/oppia/discussions) and we'll fix it. For other issues, you might need to be more independent because we might not know how to solve them either.
 
-You can also browse good first issues for each of the core Oppia Web teams to find something you'd enjoy working on. Please only choose issues that have **not yet** been assigned! Here are the project boards for the different teams:
+You can also browse good first issues for each of the core Oppia Web teams to find something you'd enjoy working on! Please only choose issues that have **not yet** been assigned, unless the issue is a "checkbox issue" with multiple claimable parts. Here are the project boards for the different teams:
 
 - Learner and Creator Experience (LaCE): https://github.com/orgs/oppia/projects/3/views/10, typically frontend or full-stack
 - Contributor Dashboard: https://github.com/orgs/oppia/projects/18/views/5, typically frontend or full-stack

--- a/Contributing-code-to-Oppia.md
+++ b/Contributing-code-to-Oppia.md
@@ -65,7 +65,7 @@ Welcome! Please make sure to follow the instructions above if you haven't alread
 
 After that, you can choose a good first issue from the [list of good first issues](https://github.com/oppia/oppia/labels/good%20first%20issue). These issues are hand-picked to ensure that you don't run into unexpected roadblocks while working on them, and each of them should have clear instructions for new contributors. If you see one that doesn't, please let us know via [GitHub Discussions](https://github.com/oppia/oppia/discussions) and we'll fix it. For other issues, you might need to be more independent because we might not know how to solve them either.
 
-You can also browse good first issues for each of the core Oppia Web teams to find something you'd enjoy working on. Please only choose issues that have **not yet** been assigned:
+You can also browse good first issues for each of the core Oppia Web teams to find something you'd enjoy working on. Please only choose issues that have **not yet** been assigned! Here are the project boards for the different teams:
 
 - Learner and Creator Experience (LaCE): https://github.com/orgs/oppia/projects/3/views/10, typically frontend or full-stack
 - Contributor Dashboard: https://github.com/orgs/oppia/projects/18/views/5, typically frontend or full-stack
@@ -77,16 +77,18 @@ When you've found a good first issue you'd like to tackle, please investigate it
 
 - Read the entire discussion thread to understand what has been tried so far.
 - Try to reproduce the issue on your local dev server. (For Contributor Dashboard issues, the [[Contributor Dashboard wiki page|Contributor-dashboard]] has some useful setup information.)
-- Figure out why the problem is happening, and find the relevant code in the Oppia repository to change. (Our [['Finding the right code to change' wiki page|Find-the-right-code-to-change]] might be helpful.)
-- If the issue is easy to fix, try to get a rough fix working on your local machine!
+- Figure out why the problem is happening, and find the relevant code in the Oppia repository to change. (The [['Finding the right code to change' wiki page|Find-the-right-code-to-change]] might be helpful.) If you have trouble with this, feel free to ask on [GitHub Discussion](https://github.com/oppia/oppia/discussions) and explain what you've tried doing so far.
+- If the issue is easy to fix, try to get a rough fix working on your local dev server!
 
 Once you have a good understanding of the issue, you can ask for it to be assigned to you by leaving a comment as follows:
 
 - Explain clearly how you'd tackle the issue (at a minimum, point to which file(s) you'd modify and describe the changes you'd make).
-- Show a screenshot or code snippet demonstrating your proposed fix.
+- If possible, show a screenshot or code snippet demonstrating your proposed fix.
 - @-mention the leads of the corresponding project the issue falls under, letting them know you'd like to work on it. (The leads are: @SanjaySajuJacob and @Priyansh61 for [LaCE](https://github.com/orgs/oppia/projects/3/views/8?pane=info); @sagangwee and @chris7716 for [Contributor Dashboard](https://github.com/orgs/oppia/projects/18/views/4?pane=info); @U8NWXD and @gp201 for [Developer Workflow](https://github.com/orgs/oppia/projects/8?pane=info).)
 
-If your explanation makes sense, we'll assign the issue to you. Once assigned, feel free to submit a PR by following the [[instructions for making a PR|Make-a-pull-request]]. If you run into any problems, feel free to create a [GitHub Discussion](https://github.com/oppia/oppia/discussions) and get help from the Oppia community, or [request a mentor](https://forms.gle/udsRP4WQgLcez9Zm8) if you'd like individual support.
+If your explanation makes sense, we'll assign the issue to you. Once assigned, feel free to submit a PR by following the [[instructions for making a PR|Make-a-pull-request]].
+
+If you run into any problems, feel free to create a [GitHub Discussion](https://github.com/oppia/oppia/discussions) and get help from the Oppia community, or [request a mentor](https://forms.gle/udsRP4WQgLcez9Zm8) if you'd like individual support.
 
 **Important Note**: Please follow the [[PR instructions|Make-a-pull-request]] carefully! Otherwise your PR review may be delayed or your PR may be closed.
 

--- a/Contributing-code-to-Oppia.md
+++ b/Contributing-code-to-Oppia.md
@@ -65,21 +65,28 @@ Welcome! Please make sure to follow the instructions above if you haven't alread
 
 After that, you can choose a good first issue from the [list of good first issues](https://github.com/oppia/oppia/labels/good%20first%20issue). These issues are hand-picked to ensure that you don't run into unexpected roadblocks while working on them, and each of them should have clear instructions for new contributors. If you see one that doesn't, please let us know via [GitHub Discussions](https://github.com/oppia/oppia/discussions) and we'll fix it. For other issues, you might need to be more independent because we might not know how to solve them either.
 
-You can also browse good first issues for each of the core Oppia Web teams to find something you'd enjoy working on:
+You can also browse good first issues for each of the core Oppia Web teams to find something you'd enjoy working on. Please only choose issues that have **not yet** been assigned:
 
 - Learner and Creator Experience (LaCE): https://github.com/orgs/oppia/projects/3/views/10, typically frontend or full-stack
-- Contributor Dashboard: https://github.com/orgs/oppia/projects/18/views/5, typically full-stack
+- Contributor Dashboard: https://github.com/orgs/oppia/projects/18/views/5, typically frontend or full-stack
 - Developer Workflow: https://github.com/orgs/oppia/projects/8/views/10, typically backend or frontend
 
 ### Choosing a good first issue
 
-When you've found a good first issue you'd like to tackle, please leave a comment on it that:
+When you've found a good first issue you'd like to tackle, please investigate it first to understand why the issue is happening. Here are some things you should do:
 
-- @-mentions the lead(s) of the corresponding project that the issue falls under (see details for [LaCE](https://github.com/orgs/oppia/projects/3/views/8?pane=info), [Contributor Dashboard](https://github.com/orgs/oppia/projects/18/views/4?pane=info) or [Developer Workflow](https://github.com/orgs/oppia/projects/8?pane=info)), letting them know you'd like to work on it.
-- says which part of the issue you're taking, if the issue is divided into subparts, and
-- describes in more detail how you'd tackle the issue (e.g. explain which file(s) you would modify and what changes you would make). If your explanation makes sense, we'll assign the issue to you.
+- Read the entire discussion thread to understand what has been tried so far.
+- Try to reproduce the issue on your local dev server. (For Contributor Dashboard issues, the [[Contributor Dashboard wiki page|Contributor-dashboard]] has some useful setup information.)
+- Figure out why the problem is happening, and find the relevant code in the Oppia repository to change. (Our [['Finding the right code to change' wiki page|Find-the-right-code-to-change]] might be helpful.)
+- If the issue is easy to fix, try to get a rough fix working on your local machine!
 
-Once you've written that comment, feel free to go ahead and submit a PR for it by following the [[instructions for making a PR|Make-a-pull-request]]. You don't need to wait for approval to get started! If you run into any issues, feel free to create a [GitHub Discussion](https://github.com/oppia/oppia/discussions) and get help from the Oppia community, or [request a mentor](https://forms.gle/udsRP4WQgLcez9Zm8) if you'd like individual support.
+Once you have a good understanding of the issue, you can ask for it to be assigned to you by leaving a comment as follows:
+
+- Explain clearly how you'd tackle the issue (at a minimum, point to which file(s) you'd modify and describe the changes you'd make).
+- Show a screenshot or code snippet demonstrating your proposed fix.
+- @-mention the leads of the corresponding project the issue falls under, letting them know you'd like to work on it. (The leads are: @SanjaySajuJacob and @Priyansh61 for [LaCE](https://github.com/orgs/oppia/projects/3/views/8?pane=info); @sagangwee and @chris7716 for [Contributor Dashboard](https://github.com/orgs/oppia/projects/18/views/4?pane=info); @U8NWXD and @gp201 for [Developer Workflow](https://github.com/orgs/oppia/projects/8?pane=info).)
+
+If your explanation makes sense, we'll assign the issue to you. Once assigned, feel free to submit a PR by following the [[instructions for making a PR|Make-a-pull-request]]. If you run into any problems, feel free to create a [GitHub Discussion](https://github.com/oppia/oppia/discussions) and get help from the Oppia community, or [request a mentor](https://forms.gle/udsRP4WQgLcez9Zm8) if you'd like individual support.
 
 **Important Note**: Please follow the [[PR instructions|Make-a-pull-request]] carefully! Otherwise your PR review may be delayed or your PR may be closed.
 

--- a/Google-Summer-of-Code-2023.md
+++ b/Google-Summer-of-Code-2023.md
@@ -42,11 +42,11 @@ Welcome! If you're interested in applying to work with Oppia for GSoC, please fo
     - Play some lessons on [Oppia.org](https://www.oppia.org/learn/math), which hosts a live instance of Oppia.
 
 3. To get started with development, read and follow the instructions in the contributors' guide carefully ([Oppia Web](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#setting-things-up)).
-    - **Note!** Oppia Android won't be offering GSoC projects in 2023, but will be doing so again from 2024 onwards
+    - **Note!** Oppia Android won't be offering GSoC projects in 2023, but will be doing so again from 2024 onwards.
 
 4. Do one or more starter projects to become familiar with the contribution process. This will help us get an idea of what it's like to work with you. It will also help you get a better understanding of the codebase and our development process, which may help with writing a good project proposal. Once you've merged at least 2 pull requests, you will get an invitation to become a collaborator to the Oppia repository and be officially onboarded! **This step is a prerequisite** to applying for GSoC.
 
-   - **Pro-tip!** Quality is more important than quantity; we want to see examples of your best work. So, please make sure to follow the [tips for success](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#tips-for-success), manually test your code before submitting (to ensure it does what you want it to and doesn't break anything else), ensure that your code conforms to the [style rules](https://github.com/oppia/oppia/wiki/Coding-style-guide), and pay attention to small details. These are good skills to learn when developing software in general, and they will also help you build credibility as a responsible developer who can be trusted to be a good steward of the Oppia codebase.
+   - **Pro-tip!** Quality is more important than quantity; we want to see examples of your best work. So, please make sure to read the [["getting started" guide|Contributing-code-to-Oppia]] and [[PR instructions|Make-a-pull-request]] carefully, follow the [tips for success](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#tips-for-success), manually test your code before submitting (to ensure it does what you want it to and doesn't break anything else), ensure that your code conforms to the [style rules](https://github.com/oppia/oppia/wiki/Coding-style-guide), and pay attention to small details. These are good skills to learn when developing software in general, and they will also help you build credibility as a responsible developer who can be trusted to be a good steward of the Oppia codebase.
 
 5. Select one or more [GSoC project ideas](#oppias-project-ideas-list) that you're most interested in, and write your project proposal! We strongly encourage you to discuss your project ideas and share your proposal with the community, so that you can get feedback and ensure that what you're writing makes sense to others. Please follow the instructions in the [GSoC proposal template](#gsoc-proposal-template) section to do this.
 
@@ -118,7 +118,7 @@ A: Yes, GSoC might not be the best choice if you don't have enough time during t
 **Q: Why doesn't Oppia provide difficulty levels for projects?**
 
 A: Difficulty can vary from person to person depending on the skills required which is why we list all the prerequisite skills for each project.
- 
+
 ## Dates and Deadlines
 
 Noteworthy dates for 2023 ([Full Timeline](https://developers.google.com/open-source/gsoc/timeline)):

--- a/Google-Summer-of-Code-2023.md
+++ b/Google-Summer-of-Code-2023.md
@@ -35,7 +35,7 @@ GSoC is an excellent opportunity for new contributors to get paid to work on an 
 
 Welcome! If you're interested in applying to work with Oppia for GSoC, please follow these steps:
 
-1. Sign up to the [oppia-gsoc-announce@](https://groups.google.com/forum/#!forum/oppia-gsoc-announce) mailing list in order to receive important notifications about Oppia's participation in GSoC. If you like, you can turn on the notification for github discussions to  participate in general discussion related to Oppia's involvement in GSoC. Make sure to set your preferences correctly so that you actually get the emails!
+1. Sign up to the [oppia-gsoc-announce@](https://groups.google.com/forum/#!forum/oppia-gsoc-announce) mailing list in order to receive important notifications about Oppia's participation in GSoC. If you like, you can also turn on notifications for [Github Discussions](https://github.com/oppia/oppia/discussions) to participate in general discussion related to Oppia's involvement in GSoC. Make sure to set your preferences correctly so that you actually get the emails!
 
 2. Get a better understanding of what Oppia is about:
     - Read the [user documentation](http://oppia.github.io/#/) to become familiar with important concepts like explorations and interactions.

--- a/Make-a-pull-request.md
+++ b/Make-a-pull-request.md
@@ -98,6 +98,8 @@ Once your feature is ready, you can open a pull request (PR)!
 
   **WARNING: If your PR only fixes a specific part of the issue, start the title with "Fix part of issue #bugnum:" instead so that the original issue is not auto-closed by GitHub when the PR is merged.**
 
+* Write a clear description of your PR that explains why the change is being made, how the change was made, as well as any identified risks and resulting countermeasures. See [here](https://github.com/oppia/oppia-android/pull/4757#issue-1461272376) for a good example -- your description does not have to be this long, but this gives an idea of what sorts of things to include.
+
 * Fill out the rest of the PR checklist.
 
 * Add the screen recording you saved to the description.
@@ -149,7 +151,7 @@ When your reviewer has completed their review, they will reassign the pull reque
 
 * **Always make commits locally, and then push to GitHub.** Don't make changes using the online GitHub editor -- this bypasses lint/presubmit checks, and will cause the code on GitHub to diverge from the code on your machine.
 
-* **Never force-push changes to GitHub.** This will lead to the PR being closed.
+* **Never force-push changes to GitHub, or rebase your PR.** This will lead to the PR being closed.
 
 * As you are making changes, track them by replying to each comment via the Files Changed tab. Each reply should be either "Done" or a response explaining why the corresponding suggestion wasn't implemented. Also, please **do not** mark the comment as resolved, since this just makes it harder to actually read the comment thread. Also, please **use the 'Start a review' button** (rather than the 'Add single comment' button) to write draft comments, so that you don't publish them before the code is ready.
 

--- a/Make-a-pull-request.md
+++ b/Make-a-pull-request.md
@@ -98,7 +98,7 @@ Once your feature is ready, you can open a pull request (PR)!
 
   **WARNING: If your PR only fixes a specific part of the issue, start the title with "Fix part of issue #bugnum:" instead so that the original issue is not auto-closed by GitHub when the PR is merged.**
 
-* Write a clear description of your PR that explains why the change is being made, how the change was made, as well as any identified risks and resulting countermeasures. See [here](https://github.com/oppia/oppia-android/pull/4757#issue-1461272376) for a good example -- your description does not have to be this long, but this gives an idea of what sorts of things to include.
+* Write a clear description of your PR that explains why the change is being made, how the change was made, as well as any identified risks and resulting countermeasures. See [here](https://github.com/oppia/oppia-android/pull/4757#issue-1461272376) for a good example of what sorts of things to include.
 
 * Fill out the rest of the PR checklist.
 


### PR DESCRIPTION
This PR does a few things:

- Clarifies the process for choosing a good first issue
- Points to key instructions from the GSoC page and asks contributors to read those carefully
- Adds some notes to the PR process on adding a good description for the PR