### PR TITLE
Update Ubuntu version to 22.04 in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Retrieve authentication token
         id: get-token
@@ -16,7 +16,7 @@ jobs:
         with:
           app_id: ${{ secrets.OPPIA_WIKI_SYNCHRONIZER_APP_ID }}
           private_key: ${{ secrets.OPPIA_WIKI_SYNCHRONIZER_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ steps.get-token.outputs.token }}
           fetch-depth: 0


### PR DESCRIPTION
## Description
Moving from Ubuntu 18.04 to 22.04

The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023. For more details, see https://github.com/actions/runner-images/issues/6002

Also upgrades actions/checkout@v2 to actions/checkout@v3

## Proof of changes
This can only be tested post merge.