### PR TITLE
Remove references to the changelog label from the wiki pages.

### DIFF
--- a/Common-pull-request-workflows.md
+++ b/Common-pull-request-workflows.md
@@ -17,7 +17,7 @@ PRL -->|"Merge"| M("Merged")
 
 
 1. (optional) Draft PR: Authors can open draft PRs to get early feedback or debug CI tests. Reviewers usually won't leave comments on these PRs unless the author leaves a comment of the form `@reviewer_username PTAL` to request a review from GitHub user `reviewer_username`.
-2. PR ready for review: Once authors mark PRs as ready for review (or if they skip the draft PR stage entirely), reviews will automatically be requested from all code owners. Oppiabot will assign one developer (typically the developer from the changelog label) to take a first pass. Oppiabot will assign the other code owners to review once the first pass is complete.
+2. PR ready for review: Once authors mark PRs as ready for review (or if they skip the draft PR stage entirely), reviews will automatically be requested from all code owners. Oppiabot will assign the code owners to review the PR.
 3. Changes requested: Reviewers will either approve the PR or request changes. Almost all PRs will have at least some changes requested. PR authors address each comment, either by making the requested change or explaining why they think it is unnecessary. Once all comments are addressed, reviewers will re-review.
 4. LGTM: A PR gets labeled LGTM ("looks good to me") when it has sufficient reviews. This means that a code owner from each modified file has approved. When multiple developers share code ownership, only one has to approve.
 5. PR merged: PRs can be merged once CI checks pass and the LGTM label has been applied. Only members of the Oppia organization can merge PRs.
@@ -42,9 +42,8 @@ While contributing to Oppia, you will need to add different labels to issues or 
 * Added automatically:
 
   * Labels starting with `PR: don't merge`: Indicates that some problem with the PR needs to be addressed before merging. For example, one of these labels gets added if the PR author hasn't signed the CLA yet.
-* `REVIEWERS: Please add changelog label`: When a new contributor opens a PR, they don't have permission to add labels. In that case, Oppiabot adds this label to tell reviewers to assign the appropriate changelog label.
-* `stale`: This label gets added by oppiabot to PRs that have been inactive for a week. They will be automatically closed after 4 more days of inactivity.
-* `PR: LGTM`: Indicates that a PR has all necessary approvals. The PR can be merged as soon as the CI checks pass.
+  * `stale`: This label gets added by oppiabot to PRs that have been inactive for a week. They will be automatically closed after 4 more days of inactivity.
+  * `PR: LGTM`: Indicates that a PR has all necessary approvals. The PR can be merged as soon as the CI checks pass.
 
 * Added by the release team:
 

--- a/Instructions-for-Reviewers.md
+++ b/Instructions-for-Reviewers.md
@@ -4,7 +4,7 @@ When you receive a code review request, please try to do the review as soon as p
 
 ## Figuring out which PRs need your attention
 
-Simply visit this URL: https://github.com/pulls/assigned. It takes you to a list of PRs that are assigned to you, across all repositories. 
+Simply visit this URL: https://github.com/pulls/assigned. It takes you to a list of PRs that are assigned to you, across all repositories.
 
 **Note:** If you just want to restrict to the oppia/oppia repository, use https://github.com/oppia/oppia/pulls/assigned/{{USERNAME}} instead (replacing `{{USERNAME}}` with your GitHub username at the end. However, the resulting list will not include your assigned PRs from other Oppia repositories.
 
@@ -12,7 +12,6 @@ Simply visit this URL: https://github.com/pulls/assigned. It takes you to a list
 
   1. When you get an email saying a pull request has been assigned to you for review, click on the link to open it in GitHub.
   1. Ensure that the correct target branch (usually "develop") has been selected to merge the branch into.
-  1. Ensure that a "changelog" label is applied on the PR. If not, select an appropriate changelog category label for the PR.
   1. If you want to CC additional reviewers, you can do so using "/cc @username". Say why you're adding them.
 
 ## Doing the review
@@ -20,7 +19,7 @@ Simply visit this URL: https://github.com/pulls/assigned. It takes you to a list
 **Pro-tip**: You can change the review pane on the "Files Changed" tab of a PR to show the old and new versions side-by-side! This makes it easier to review the diffs. See this [GitHub help page](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-comparing-branches-in-pull-requests#diff-view-options) for more information.
 
   1. Look out for the following things:
-     * Do you understand exactly what the code is doing, without needing to dig in too much? If not, it's probably the writer's fault, and you should tell them so. The logic needs to be very clear. 
+     * Do you understand exactly what the code is doing, without needing to dig in too much? If not, it's probably the writer's fault, and you should tell them so. The logic needs to be very clear.
        * Don't be afraid, as a reviewer, about asking for the logic to be broken up or simplified. It's also totally fine (and preferable!) to ask for code to be simplified if it is hard to read (even though it may be technically correct in its current form). Code is typically written once and read many times, so we try to optimize for readability.
      * Is the code doing the right thing? (Make sure to further expand the parts above and below the code you're looking at, to ensure that you have the full context of what is going on. This is _especially_ important for complex logic -- e.g. can you find the critical bug that was introduced [here](https://github.com/oppia/oppia/pull/9141/files#diff-3d7e1efacf316f35426e24bedbd89564R128)?)
      * Does the design look sensible?
@@ -81,7 +80,7 @@ In some cases, the reviewer (contributors with write access) might want to fix t
 ### Instructions
 
 1. Add PR author fork as a new remote, `git remote add {{AUTHOR_NAME}} git@github.com:{{AUTHOR_NAME}}/oppia.git`.
-1. Locally fetch author branches, `git fetch {{AUTHOR_NAME}}`.   
+1. Locally fetch author branches, `git fetch {{AUTHOR_NAME}}`.
 1. Checkout to the fetched branch, `git checkout -b {{AUTHOR_NAME}}-{{BRANCH_NAME}} {{AUTHOR_NAME}}/{{BRANCH_NAME}}`.
 1. Update that branch from develop, `git pull upstream develop` and fix the merge conflicts as usual.
 1. Push back to the branch, `git push {{AUTHOR_NAME}} HEAD:{{BRANCH_NAME}}`.

--- a/Make-a-pull-request.md
+++ b/Make-a-pull-request.md
@@ -106,11 +106,9 @@ Once your feature is ready, you can open a pull request (PR)!
 
 * Click "Create pull request".
 
-* If you have already completed 2 pull requests and been added as a collaborator to the project, you should also add a changelog label.  If you are a new contributor, you don't have permission to do this.  Don't worry! Oppiabot will automatically ask someone to do it for you.
-
 * Oppiabot will check that you filled out the PR description correctly. If you didn't, it will leave a comment explaining what you need to do to fix it. More details on the kinds of comments Oppiabot leaves are coming soon.
 
-* GitHub will automatically assign reviewers, and Oppiabot will assign the issue's "owner" (from the changelog label) to do the first review.
+* GitHub will automatically assign reviewers, and Oppiabot will assign them as codeowners to do the first review.
 
   If you need to assign someone else but aren't a collaborator yet, leave a comment of the form `@{{reviewer username}} PTAL`, which will tell Oppiabot to assign that person for you. ("PTAL" means "Please take a look".)
 


### PR DESCRIPTION
Removes mention of the changelog label from the wiki pages, following the Oppiabot and release process upgrade to not use them any more.