### PR TITLE
Fixes 'Introduction to GitHub' dead link and adds Python resources

### DIFF
--- a/Learning-Resources.md
+++ b/Learning-Resources.md
@@ -37,4 +37,6 @@ That said, we strongly recommend that you be open to learning new things. If you
 
 * If you are new to HTML, some tutorials include [Mozilla's guide](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML) (which includes some practice assessments), as well as [this tutorial for beginners](http://htmldog.com/guides/html/beginner/).
 
+* If you are new to Python, the free [CS50p](https://cs50.harvard.edu/python/2022/) course is a great place to start learning. W3Schools' [Python Tutorial](https://www.w3schools.com/python/) is a good quick reference guide and includes interactive practice exercises. Also, check out the official Python [documentation](https://docs.python.org/3/).
+
 If you find a useful learning resource that isn't listed here, please add it to help other new contributors!

--- a/Learning-Resources.md
+++ b/Learning-Resources.md
@@ -11,7 +11,7 @@ That said, we strongly recommend that you be open to learning new things. If you
       * Levels 1, 2, and 3 from the Introduction sequence.
       * Levels 1, 2, 3, 4, 5, and 6 from Push and Pull Git Remotes.
 
-    * [Introduction to GitHub](https://lab.github.com/courses/introduction-to-github) covers how to use GitHub.
+    * [Introduction to GitHub](https://github.com/skills/introduction-to-github) covers how to use GitHub.
 
   * More advanced:
 


### PR DESCRIPTION
- Current 'Introduction to GitHub' link leads to a 404 error. The PR updates link to the correct link within GitHub Skills.
- The PR adds useful links to Python learning resources because the first paragraph of the page mentions knowledge of Python is helpful for contributing.