### PR TITLE
Drop references to updating the CHANGELOG.

### DIFF
--- a/Common-pull-request-workflows.md
+++ b/Common-pull-request-workflows.md
@@ -36,7 +36,6 @@ While contributing to Oppia, you will need to add different labels to issues or 
 
   * `dependencies`: Should be added to pull requests that update one or more dependencies.
   * `PR: Affects datastore layer`: Indicates that a PR changes the datastore layer. Adding this label notifies the developers in charge of datastore stability so they can review the PR. Sometimes this label gets added automatically by Oppiabot, but if you open a PR that changes the datastore layer and the label isn't added automatically, you should add it manually. You can also add the label without waiting for Oppiabot.
-  * Changelog (labels containing `PR CHANGELOG`): Each PR should have one of these labels added to indicate what project this PR applies to. The developer mentioned in the label will be assigned to review the PR first.
 * `PR: require post-merge sync to HEAD`: Should only be applied to pull requests which, when merged, will require all other open pull requests to be updated with the develop branch.
 
 * Added automatically:

--- a/Instructions-for-Reviewers.md
+++ b/Instructions-for-Reviewers.md
@@ -60,7 +60,7 @@ The commit message of the squash should be a clear one-line summary of the chang
 * ``Fix #bugnum: introduce the first version of the collection editor.``
 * ``Update the exploration editor to do X better.``
 
-Getting this message correct is important, since it will be used to compile the CHANGELOG during the next release. If you like, feel free to also add optional follow-up sentences after the one-line summary.
+Getting this message correct is important, since it will be used by the release team to compile the list of features for the release notes. If you like, feel free to also add optional follow-up sentences after the one-line summary.
 
 ### Who Should Merge
 


### PR DESCRIPTION
This fixes the remaining part of https://github.com/oppia/oppia/issues/17786.