### PR TITLE
Update docker troubleshooting section about network timeout and connection issues

### DIFF
--- a/Installing-Oppia-using-Docker.md
+++ b/Installing-Oppia-using-Docker.md
@@ -184,6 +184,5 @@ The Oppia development environment provides additional `make` commands that you c
 - `make init`: Initializes the Oppia development environment by building the Docker Images and starting the dev-server.
 - `make echo_flags`: This command shows the flags with thier values that are being used by the Oppia development server.
 
-## Contributing
-
-If you encounter any issues during the installation process or have suggestions for improvement, please feel free to open a discussion on [Oppia's GitHub Discussion](https://github.com/oppia/oppia/discussions)
+## Troubleshooting
+If you are facing any issues while installing Oppia using Docker, please refer to the [[Troubleshooting page|Troubleshooting]].

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -54,6 +54,7 @@ Here are some general troubleshooting tips for Oppia. The platform specific tips
 - [Docker Setup](#docker-setup)
   - [docker-desktop : Depends: docker-ce-cli but it is not installable](#docker-desktop--depends-docker-ce-cli-but-it-is-not-installable)
   - [make commands: `Operation not permitted`](#make-commands-operation-not-permitted)
+  - [Installation encounters `network timeout` or `connection error`](#installation-encounters-network-timeout-or-connection-error)
 - [If the above doesn't work](#if-the-above-doesnt-work)
 
 ### `[Errno 104] Connection reset by peer`
@@ -707,6 +708,10 @@ sudo gpasswd -a $USER docker
 [Reference]([url](https://askubuntu.com/questions/477551/how-can-i-use-docker-without-sudo))
 
 The cause of the issue is that Docker daemon binds to a unix socket by default, which is owned by root. So, when you run the make commands without admin access, it is not able to access the unix socket and hence the error is thrown.
+
+### Installation encounters `network timeout` or `connection error`
+
+If you encounter network timeout or connection errors during the Docker setup process, simply re-execute the `make build` command. This is necessary as the Docker setup may have been disrupted by network problems. By rerunning the command, the setup will pick up from the point of failure and continue accordingly.
 
 
 ## If the above doesn't work


### PR DESCRIPTION
This PR fixes #211
This PR does the following:
- add a troubleshooting link to the docker setup page
- add troubleshooting method for network timeout and connection issues