### PR TITLE
Add formatters wiki page to sidebar; add VSCode config

### DIFF
--- a/Formatters.md
+++ b/Formatters.md
@@ -3,3 +3,15 @@
 We use [prettier](https://prettier.io/) to format frontend code. It is configured based on [gts](https://github.com/google/gts). It is run as a pre-commit hook, i.e. it is executed every time you make a commit.
 
 You can set up a prettier [extension](https://github.com/prettier/prettier-vscode) for vscode as well to format files when saving. Execute `npx prettier . --write` to format the code manually from the terminal.
+
+Also, if you're using VSCode, here is a `.vscode/settings.json` that you can use:
+
+```
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "prettier.configPath": "./.prettierrc.json",
+  "prettier.ignorePath": "./.prettierignore",
+  "git.ignoreLimitWarning": true
+}
+```

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -42,6 +42,7 @@
   * **[[Good first issues|https://github.com/oppia/oppia/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22]]**
   * Coding Guidelines
     * [[Coding style guide|Coding-style-guide]]
+      * [[Formatters|Formatters]]
     * [[Guidelines for creating new files|The-File-Naming-Convention-and-Directory-Structure]]
     * [[How to add a new page|Adding-new-page]]
     * [[How to write frontend type definitions|Guide-on-defining-types]]


### PR DESCRIPTION
This PR adds the formatters wiki page to the sidebar to make it more discoverable, and also adds the VSCode config based on [this discussion](https://github.com/oppia/oppia/pull/20017#issuecomment-2016457535).