### PR TITLE
Fix SoD 2024 TOC and Headings, and Add Pre-Submission Review Instructions

### DIFF
--- a/Season-of-Docs-2024.md
+++ b/Season-of-Docs-2024.md
@@ -1,25 +1,23 @@
 ## Table of Contents
+
 * [Timeline](#the-program-timeline)
 * [Getting started](#getting-started)
 * [FAQ](#faq)
 * [Starter projects](#starter-projects)
-* [Season of Docs Proposal](#season-of-docs-proposal)
+* [SoD Statement of Interest](#sod-statement-of-interest)
   * [Template](#template)
-  * [Tips for writing a good project plan](#tips-for-writing-a-good-project-plan)
   * [Selection criteria](#selection-criteria)
-* [How to apply?](#how-to-apply)
-* [Project Ideas](#project-ideas)
-* [Other useful information](#other-useful-information)
-    * [Dates and Deadlines](#dates-and-deadlines)
-    * [List of Mentors](#list-of-potential-mentors)
-    * [Communication](#communication)
+  * [How to apply?](#how-to-apply)
+* [Project Idea](#project-idea)
+* [List of Org Admins](#list-of-org-admins)
+* [Communication](#communication)
 
 Oppia is planning to participate in the [Season of Docs](https://developers.google.com/season-of-docs/) 2024 program! This program provides support for open source projects to improve their documentation and gives professional technical writers an opportunity to gain experience in open source. The technical writers work closely with one or more mentors on finishing a project idea given by the organization.
 
 Please note that acceptance into Season of Docs isn't a prerequisite for [becoming an Oppia contributor](https://github.com/oppia/oppia/wiki). The Oppia project is run by the community for the community, and we warmly welcome anyone who'd like to help out!
 
 
-# The program timeline
+## The program timeline
 
 Please see the Season of Docs timeline here: https://developers.google.com/season-of-docs/docs/timeline.
 
@@ -30,7 +28,7 @@ In addition to the dates provided there, Oppia will follow the timeline below:
 **Selection announcement:** We expect to announce the selected technical writer on [oppia-sod-announce@](https://groups.google.com/g/oppia-sod-announce) on or before 30 Apr 2024 at 18:00 UTC. Note that this is conditional on Oppia being accepted to the Summer of Docs program for 2024 (the results of which will be announced by Google on 10 Apr 2024 at 18:00 UTC).
 
 
-# Getting started
+## Getting started
 
 If you're interested in applying to work with Oppia for Season of Docs, please follow these steps:
 
@@ -49,13 +47,13 @@ If you're interested in applying to work with Oppia for Season of Docs, please f
 1. When you're ready, submit your application to our application form following the guidelines [below](#how-to-apply).
 
 
-# FAQ
+## FAQ
 
 **Q: How can I increase my chances of getting selected?**
 
 A: Writing a good project proposal, engaging with the community, helping other applicants, successfully contributing to [already-existing documentation](https://github.com/oppia/oppia/wiki), gaining and showing familiarity with the parts of Oppia you propose to document, and demonstrating that you can work independently can all help you.
 
-# Starter projects
+## Starter projects
 
 ### Address any issue on the Oppia wiki repository
 
@@ -79,13 +77,13 @@ Steps to follow:
 - Submit a link to your doc/journal as part of your statement of interest.
 
 
-# SoD Statement of Interest
+## SoD Statement of Interest
 **Important**: Please make sure that your final statement of interest is self-contained! In particular, to be fair to all applicants, key components of the proposal should not be editable after the deadline, and you shouldn't assume that reviewers will follow external links (except for those describing contributions to previous documentation projects, including starter projects).
 
-## Template
+### Template
 When submitting a proposal, please use the provided [SoD statement of interest template](https://docs.google.com/document/d/1vr9diIcnAxEdH9XC9mv4KYhzNl9S6T5e1x2FIT-7eJs/edit). This template contains additional Oppia-specific guidance for Season of Docs, so be sure to read it carefully!
 
-## Selection criteria
+### Selection criteria
 
 In order to select technical writers for the project, we will mainly be looking at three things:
 
@@ -101,24 +99,24 @@ For the "Statement of interest", we generally look for a clear indication that t
 - A clear analysis of the original project idea, with a strong focus on creating clear and understandable documentation for users or developers. The proposal should be sufficiently concrete to demonstrate that the applicant is familiar with the scope of the problem they're tackling, and may include pointers to parts of the Oppia codebase.
 - A concrete, specific breakdown of the work to be done for each milestone.
 
-## How to apply?
+### How to apply?
 
 Applicants are expected to fill up the [application form](https://forms.gle/py5rWVemffdgdPbz6) and upload the final "Statement of interest (SOI)" in PDF format before the deadline. If you fail to submit the form before the deadline, then we will not be able to accept your application.
 
 Per the guidance in the official [Season of Docs guide](https://developers.google.com/season-of-docs/docs/tech-writer-guide#application_phase), we will reach out directly if we would like to work with you or discuss your statement of interest further.
 
 
-# Project Idea
+## Project Idea
 
-## Develop tutorials to help contributors tackle issues in new domains
+### Develop tutorials to help contributors tackle issues in new domains
 
-### Problem statement
+#### Problem statement
 
 The Oppia project has a large technical community, comprising numerous open-source contributors from around the world. However, we have been seeing that quite a number of contributors who sign up to start contributing to Oppia are having trouble getting started on their first issue.
 
 While there is plenty of documentation on the wiki that outlines the basic steps of how to get started and run tests etc., we are concerned that new contributors may not have enough support to map the documentation to the next step in their development journey after they get Oppia set up locally. After an analysis of our documentation using the [Diátaxis framework](https://diataxis.fr/), we believe that part of the issue is that our documentation has a significant lack of tutorials. The aim of this project is to remedy this.
 
-### Project’s scope
+#### Project’s scope
 
 This project involves three parts. Most of the work for the project is contained in the third part, but the first two parts build important foundations:
 
@@ -130,13 +128,13 @@ This project involves three parts. Most of the work for the project is contained
 
 Note that all documentation will be submitted to our [GitHub wiki repository](https://github.com/oppia/oppia-web-developer-docs/), though you might want to use tools like Google Docs to draft tutorials and get preliminary feedback on those.
 
-### How would we measure success?
+#### How would we measure success?
 
 - Increase in the number of new contributors who are able to successfully merge a PR for their first issue.
 - Increase in the number of contributors onboarded to one of Oppia's development teams (typically after completing two starter issues).
 - Increase in the number of closed "good first issues".
 
-### Knowledge/Skills needed
+#### Knowledge/Skills needed
 
 * Technical writing experience
 * Teaching experience

--- a/Season-of-Docs-2024.md
+++ b/Season-of-Docs-2024.md
@@ -153,3 +153,5 @@ Note that all documentation will be submitted to our [GitHub wiki repository](ht
 ## Communication
 
 If you have questions pertaining to how-to-get-started with the various codebases, please ask them on GitHub Discussions ([Web](https://github.com/oppia/oppia/discussions), [Android](https://github.com/oppia/oppia-android/discussions)). Please be specific when asking questions; this makes it easier for us to help you.
+
+Please use the public channels above wherever possible so that others can learn from the answer to your questions. If you need to contact the org admins confidentially, you can email them at sod-2024-admins@oppia.org.

--- a/Season-of-Docs-2024.md
+++ b/Season-of-Docs-2024.md
@@ -103,6 +103,8 @@ For the "Statement of interest", we generally look for a clear indication that t
 
 Applicants are expected to fill up the [application form](https://forms.gle/py5rWVemffdgdPbz6) and upload the final "Statement of interest (SOI)" in PDF format before the deadline. If you fail to submit the form before the deadline, then we will not be able to accept your application.
 
+You may optionally submit draft SOIs to the org admins for pre-submission review. Please draft your SOI in Google Docs and send an email to the org admins at sod-2024-admins@oppia.org with a link to your draft. The org admins will review your draft and make suggestions to help you improve your SOI. Please make sure you give everyone with the link permission to comment so that we can give you feedback! Pre-submission is completely optional, and we may not be able to respond to everyone's drafts. **Please do not risk missing the submission deadline, even if you are waiting for feedback.**
+
 Per the guidance in the official [Season of Docs guide](https://developers.google.com/season-of-docs/docs/tech-writer-guide#application_phase), we will reach out directly if we would like to work with you or discuss your statement of interest further.
 
 


### PR DESCRIPTION
This PR makes the following changes to the SoD 2024 page:
* Fix TOC links
* Fix headings to avoid using h1 (since GitHub automatically uses the file name to generate an h1 title)
* Add instructions for pre-submission review
* Add the SoD admins email for confidential contact