### PR TITLE
Update Installing-Oppia-(Mac-OS;-Python-3).md

### DIFF
--- a/Installing-Oppia-(Mac-OS;-Python-3).md
+++ b/Installing-Oppia-(Mac-OS;-Python-3).md
@@ -68,7 +68,7 @@ Oppia relies on a number of programs and third-party libraries. Many of these li
 
 2. Install [direnv](https://direnv.net/).
 
-   After finishing with the official installation instructions, you should also create a `~/.direnvrc` file with the following content:
+   After finishing with the official installation instructions, you should also create a `~/.config/direnv/direnvrc` file with the following content:
 
    ```bash
    use_python() {


### PR DESCRIPTION
The previous instructions would always lead to an error on my mac M3, stating "use_python: command not found", even though I had the script in my .direnv file. After reviewing the direnv documentation, I discovered an article where they were using a ruby script, but they added it to the ~/.config/direnv/direnvrc file. After adding my script to the file, direnv was able to load the script and I was able to run the build! Hopefully this can help any other mac users with the same issue! @seanlip @gp201 
<img width="753" alt="Screenshot 2024-07-22 at 12 47 05 PM" src="https://github.com/user-attachments/assets/866230cd-8a8d-4be1-8cd0-645787837a68">
