### PR TITLE
Fix: add space to fix Docker instructions

### DIFF
--- a/Installing-Oppia-using-Docker.md
+++ b/Installing-Oppia-using-Docker.md
@@ -79,7 +79,7 @@ To install Oppia under Docker, follow these steps:
    For developers who are using SSH to push to their git repository, please change the SSH config at `~/.ssh/config` to ensure that the git pre-push hook doesn't time out at 5 minutes. In order to do this, add the following lines to `~/.ssh/config` ([Reference](https://stackoverflow.com/a/65818657)):
 
       ```console
-      Host*
+      Host *
          ServerAliveInterval 60
          ServerAliveCountMax 30
       ```


### PR DESCRIPTION
Fixes the SSH config example by adding a space between Host and *. This prevents the following error after copying it into the .ssh/config file:
/Users/xxx/.ssh/config line 1: no argument after keyword "host*"
/Users/xxx/.ssh/config: terminating, 1 bad configuration options