### PR TITLE
removed references to deprecated python_utils file

### DIFF
--- a/Coding-style-guide.md
+++ b/Coding-style-guide.md
@@ -20,6 +20,7 @@ If you use [Sublime Text](http://www.sublimetext.com/), consider installing the 
 ## Python
 - Consider using a frozenset or tuple to a list, if the data structure is not meant to be subsequently modified. This applies especially to constants.
 - If you need to raise an Exception, just do `raise Exception` -- no need to define custom exceptions. We tend to use exceptions fairly sparingly, though.
+- Do not use `str()` under any circumstances. Please try to use `python_utils.convert_to_bytes()` or the `b'` prefix for the strings used in webapp2\'s built-in methods or for strings used directly in NDB datastore models. If you need to cast ints/floats to strings, please use `python_utils.UNICODE()` instead. Avoid casting strings to other types of strings using str(), unicode(), etc. Also, there should be no need to prefix any string literals with b' or u', since all string literals in Python files are prefixed with `u'` by default (due to the import of unicode_literals at the top of the file).
 - Otherwise, please follow the [Google Python style guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md). In particular:
   - There should be two empty lines before any top-level class or function definition.
   - It's OK for the initial documentation string to be more than one line long.
@@ -73,6 +74,25 @@ If you use [Sublime Text](http://www.sublimetext.com/), consider installing the 
 
   - Imports should be in three groups: standard libraries, files within the Oppia codebase, and third-party files. Each group should be separated by a single newline. Within each group, imports should be organized alphabetically. If you have additional questions, feel free to reference the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#313-imports-formatting).
 
+### Handling bytes and string in Python 3
+- Python 3 differs a lot in handling strings and bytes from Python 2 (you can read more about this in [this article](https://betterprogramming.pub/strings-unicode-and-bytes-in-python-3-everything-you-always-wanted-to-know-27dc02ff2686) or in this [Pragmatic Unicode talk](https://nedbatchelder.com/text/unipain.html)). Basically, strings (`str`) in Python 3 are Unicode by default and “bytes” (`bytes`) are lists of integers from 0 to 255 (lists of 8 bits). There is no implicit conversion between `str` and `bytes` in Python 3, so any conversion needs to be done explicitly using `encode` (`str` → `bytes`) and `decode` (`bytes` → `str`) functions.
+
+Throughout Oppia, we typically use strings. However, you may come across bytes in places where there is an interaction with some outside library or API — for example, when standard input or output is read or written, or when data is read from or written to files. Some standard Python libraries also only accept bytes. 
+
+#### Rules for handling strings and bytes
+##### Bytes outside, strings inside
+
+The general rule you should follow is to keep all text in Oppia as strings, where possible. If a conversion to bytes is necessary, that conversion should happen as close to the “edges” of the app as possible. So, for example:
+- When you receive bytes from some library, immediately convert them to string using decode.
+- If you need to use a function that needs bytes, use encode to convert the string to bytes immediately before you call the function.
+
+##### Use utf-8 (or ascii)
+
+In the Oppia codebase all data (that we can decide about) should be encoded/decoded using utf-8 encoding (`encode('utf-8')`). If you find a case where utf-8 cannot be used, please raise this with the Core Maintainers team.
+
+If, in some case, an external source returns or receives data with a different encoding, it is fine to use that encoding only for that source. However, please first be sure to investigate whether that source can be configured to use utf-8 instead.
+
+
 ### Apache Beam logic
   - For pipe operations that span multiple lines, always have the pipe operator (`|`) begin on the new line.
 
@@ -104,6 +124,25 @@ If you use [Sublime Text](http://www.sublimetext.com/), consider installing the 
     pcoll = (
         input_pcoll | "Sort" >> Sort() | "Unique" >> Unique())
     ````
+
+
+## Prettier
+
+We use [prettier](https://prettier.io/) to format frontend code. It is configured based on [gts](https://github.com/google/gts). It is run as a pre-commit hook, i.e. it is executed every time you make a commit.
+
+You can set up a prettier [extension](https://github.com/prettier/prettier-vscode) for vscode as well to format files when saving. Execute `npx prettier . --write` to format the code manually from the terminal.
+
+Also, if you're using VSCode, here is a `.vscode/settings.json` that you can use:
+
+```
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "prettier.configPath": "./.prettierrc.json",
+  "prettier.ignorePath": "./.prettierignore",
+  "git.ignoreLimitWarning": true
+}
+```
 
 ## JavaScript
 _General note: We use the ES2017 standard for our JavaScript/TypeScript code. (See [tsconfig.json](https://github.com/oppia/oppia/blob/57333f23af7b67914dc039671f4bc4e029fbb6e7/tsconfig.json#L4).)_

--- a/Coding-style-guide.md
+++ b/Coding-style-guide.md
@@ -20,7 +20,6 @@ If you use [Sublime Text](http://www.sublimetext.com/), consider installing the 
 ## Python
 - Consider using a frozenset or tuple to a list, if the data structure is not meant to be subsequently modified. This applies especially to constants.
 - If you need to raise an Exception, just do `raise Exception` -- no need to define custom exceptions. We tend to use exceptions fairly sparingly, though.
-- Do not use `str()` under any circumstances. Please try to use `python_utils.convert_to_bytes()` or the `b'` prefix for the strings used in webapp2\'s built-in methods or for strings used directly in NDB datastore models. If you need to cast ints/floats to strings, please use `python_utils.UNICODE()` instead. Avoid casting strings to other types of strings using str(), unicode(), etc. Also, there should be no need to prefix any string literals with b' or u', since all string literals in Python files are prefixed with `u'` by default (due to the import of unicode_literals at the top of the file).
 - Otherwise, please follow the [Google Python style guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md). In particular:
   - There should be two empty lines before any top-level class or function definition.
   - It's OK for the initial documentation string to be more than one line long.

--- a/Coding-style-guide.md
+++ b/Coding-style-guide.md
@@ -20,7 +20,6 @@ If you use [Sublime Text](http://www.sublimetext.com/), consider installing the 
 ## Python
 - Consider using a frozenset or tuple to a list, if the data structure is not meant to be subsequently modified. This applies especially to constants.
 - If you need to raise an Exception, just do `raise Exception` -- no need to define custom exceptions. We tend to use exceptions fairly sparingly, though.
-- Do not use `str()` under any circumstances. Please try to use `python_utils.convert_to_bytes()` or the `b'` prefix for the strings used in webapp2\'s built-in methods or for strings used directly in NDB datastore models. If you need to cast ints/floats to strings, please use `python_utils.UNICODE()` instead. Avoid casting strings to other types of strings using str(), unicode(), etc. Also, there should be no need to prefix any string literals with b' or u', since all string literals in Python files are prefixed with `u'` by default (due to the import of unicode_literals at the top of the file).
 - Otherwise, please follow the [Google Python style guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md). In particular:
   - There should be two empty lines before any top-level class or function definition.
   - It's OK for the initial documentation string to be more than one line long.
@@ -74,25 +73,6 @@ If you use [Sublime Text](http://www.sublimetext.com/), consider installing the 
 
   - Imports should be in three groups: standard libraries, files within the Oppia codebase, and third-party files. Each group should be separated by a single newline. Within each group, imports should be organized alphabetically. If you have additional questions, feel free to reference the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#313-imports-formatting).
 
-### Handling bytes and string in Python 3
-- Python 3 differs a lot in handling strings and bytes from Python 2 (you can read more about this in [this article](https://betterprogramming.pub/strings-unicode-and-bytes-in-python-3-everything-you-always-wanted-to-know-27dc02ff2686) or in this [Pragmatic Unicode talk](https://nedbatchelder.com/text/unipain.html)). Basically, strings (`str`) in Python 3 are Unicode by default and “bytes” (`bytes`) are lists of integers from 0 to 255 (lists of 8 bits). There is no implicit conversion between `str` and `bytes` in Python 3, so any conversion needs to be done explicitly using `encode` (`str` → `bytes`) and `decode` (`bytes` → `str`) functions.
-
-Throughout Oppia, we typically use strings. However, you may come across bytes in places where there is an interaction with some outside library or API — for example, when standard input or output is read or written, or when data is read from or written to files. Some standard Python libraries also only accept bytes. 
-
-#### Rules for handling strings and bytes
-##### Bytes outside, strings inside
-
-The general rule you should follow is to keep all text in Oppia as strings, where possible. If a conversion to bytes is necessary, that conversion should happen as close to the “edges” of the app as possible. So, for example:
-- When you receive bytes from some library, immediately convert them to string using decode.
-- If you need to use a function that needs bytes, use encode to convert the string to bytes immediately before you call the function.
-
-##### Use utf-8 (or ascii)
-
-In the Oppia codebase all data (that we can decide about) should be encoded/decoded using utf-8 encoding (`encode('utf-8')`). If you find a case where utf-8 cannot be used, please raise this with the Core Maintainers team.
-
-If, in some case, an external source returns or receives data with a different encoding, it is fine to use that encoding only for that source. However, please first be sure to investigate whether that source can be configured to use utf-8 instead.
-
-
 ### Apache Beam logic
   - For pipe operations that span multiple lines, always have the pipe operator (`|`) begin on the new line.
 
@@ -124,25 +104,6 @@ If, in some case, an external source returns or receives data with a different e
     pcoll = (
         input_pcoll | "Sort" >> Sort() | "Unique" >> Unique())
     ````
-
-
-## Prettier
-
-We use [prettier](https://prettier.io/) to format frontend code. It is configured based on [gts](https://github.com/google/gts). It is run as a pre-commit hook, i.e. it is executed every time you make a commit.
-
-You can set up a prettier [extension](https://github.com/prettier/prettier-vscode) for vscode as well to format files when saving. Execute `npx prettier . --write` to format the code manually from the terminal.
-
-Also, if you're using VSCode, here is a `.vscode/settings.json` that you can use:
-
-```
-{
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true,
-  "prettier.configPath": "./.prettierrc.json",
-  "prettier.ignorePath": "./.prettierignore",
-  "git.ignoreLimitWarning": true
-}
-```
 
 ## JavaScript
 _General note: We use the ES2017 standard for our JavaScript/TypeScript code. (See [tsconfig.json](https://github.com/oppia/oppia/blob/57333f23af7b67914dc039671f4bc4e029fbb6e7/tsconfig.json#L4).)_

--- a/Custom-Pylint-checks.md
+++ b/Custom-Pylint-checks.md
@@ -500,10 +500,10 @@ def test_finds_hello_world_assignment(self):
     filename = temp_file.name
 
     with open(filename, 'w') as tmp:
-            tmp.write("""
-            s = "Hello, world!"
-            print("Hello, world!")
-            """)
+        tmp.write("""
+        s = "Hello, world!"
+        print("Hello, world!")
+        """)
 
     node.file = filename
     node.path = filename

--- a/Custom-Pylint-checks.md
+++ b/Custom-Pylint-checks.md
@@ -452,7 +452,7 @@ def test_finds_hello_world_assignment(self):
         doc='Custom test')
     temp_file = tempfile.NamedTemporaryFile()
     filename = temp_file.name
-    with python_utils.open_file(filename, 'w') as tmp:
+    with open(filename, 'w') as tmp:
         tmp.write('s = "Hello, world!"')
     node.file = filename
     node.path = filename
@@ -472,7 +472,7 @@ def test_finds_hello_world_func_call(self):
         doc='Custom test')
     temp_file = tempfile.NamedTemporaryFile()
     filename = temp_file.name
-    with python_utils.open_file(filename, 'w') as tmp:
+    with open(filename, 'w') as tmp:
         tmp.write('print("Hello, world!")')
     node.file = filename
     node.path = filename
@@ -499,11 +499,11 @@ def test_finds_hello_world_assignment(self):
     temp_file = tempfile.NamedTemporaryFile()
     filename = temp_file.name
 
-    with python_utils.open_file(filename, 'w') as tmp:
-        tmp.write("""
-        s = "Hello, world!"
-        print("Hello, world!")
-        """)
+    with open(filename, 'w') as tmp:
+            tmp.write("""
+            s = "Hello, world!"
+            print("Hello, world!")
+            """)
 
     node.file = filename
     node.path = filename

--- a/Find-the-right-code-to-change.md
+++ b/Find-the-right-code-to-change.md
@@ -193,7 +193,7 @@ Next let's identify the backend files involved in handling updates to the user's
    +             'User experience exceeds maximum character limit: %s'
    +             % feconf.MAX_BIO_LENGTH_IN_CHARS)
    +     else:
-   +         python_utils.PRINT(
+   +         print(
    +             'DEBUG Controller received update: ' +
    +             data)
    ```
@@ -218,7 +218,7 @@ Next let's identify the backend files involved in handling updates to the user's
        """
        user_settings = get_user_settings(user_id, strict=True)
        user_settings.user_experience = user_experience
-       python_utils.PRINT(
+       print(
            'DEBUG: update_user_experience: ' + user_experience)
        _save_user_settings(user_settings)
     ```
@@ -233,7 +233,7 @@ Next let's identify the backend files involved in handling updates to the user's
                  'User experience exceeds maximum character limit: %s'
                  % feconf.MAX_BIO_LENGTH_IN_CHARS)
          else:
-   -         python_utils.PRINT(
+   -         print(
    -             'DEBUG Controller received update: ' +
    -             data)
    +         user_services.update_user_experience(self.user_id, data)
@@ -279,7 +279,7 @@ Next let's identify the backend files involved in handling updates to the user's
    First, let's add a `user_experience` argument to the constructor, assign that argument to an instance field, and update the appropriate docstrings:
 
    ```diff
-   @@ -55,6 +55,7 @@ class UserSettings(python_utils.OBJECT):
+   @@ -55,6 +55,7 @@ class UserSettings:
                 a dataURI string.
             default_dashboard: str or None. The default dashboard of the user.
             user_bio: str. User-specified biography.
@@ -287,7 +287,7 @@ Next let's identify the backend files involved in handling updates to the user's
             subject_interests: list(str) or None. Subject interests specified by
                 the user.
             first_contribution_msec: float or None. The time in milliseconds when
-   @@ -77,7 +78,7 @@ class UserSettings(python_utils.OBJECT):
+   @@ -77,7 +78,7 @@ class UserSettings:
                 profile_picture_data_url=None, default_dashboard=None,
                 creator_dashboard_display_pref=(
                     constants.ALLOWED_CREATOR_DASHBOARD_DISPLAY_PREFS['CARD']),
@@ -296,7 +296,7 @@ Next let's identify the backend files involved in handling updates to the user's
                 preferred_language_codes=None, preferred_site_language_code=None,
                 preferred_audio_language_code=None, pin=None, display_alias=None,
                 deleted=False, created_on=None):
-   @@ -106,6 +107,7 @@ class UserSettings(python_utils.OBJECT):
+   @@ -106,6 +107,7 @@ class UserSettings:
                 creator_dashboard_display_pref: str. The creator dashboard of the
                     user.
                 user_bio: str. User-specified biography.
@@ -304,7 +304,7 @@ Next let's identify the backend files involved in handling updates to the user's
                 subject_interests: list(str) or None. Subject interests specified by
                     the user.
                 first_contribution_msec: float or None. The time in milliseconds
-   @@ -140,6 +142,7 @@ class UserSettings(python_utils.OBJECT):
+   @@ -140,6 +142,7 @@ class UserSettings:
             self.default_dashboard = default_dashboard
             self.creator_dashboard_display_pref = creator_dashboard_display_pref
             self.user_bio = user_bio
@@ -317,7 +317,7 @@ Next let's identify the backend files involved in handling updates to the user's
    Next, we need to update the `to_dict` function to include the `user_experience` field:
 
    ```diff
-   @@ -293,6 +296,7 @@ class UserSettings(python_utils.OBJECT):
+   @@ -293,6 +296,7 @@ class UserSettings:
                 'creator_dashboard_display_pref': (
                     self.creator_dashboard_display_pref),
                 'user_bio': self.user_bio,
@@ -369,7 +369,7 @@ Now that we have the user experience field added to all the models, we can updat
          logging.error('Could not find user with id %s' % user_id)
          raise Exception('User not found.')
    + if user_settings:
-   +     python_utils.PRINT(
+   +     print(
    +         'DEBUG get_user_settings experience: ' +
    +         user_settings.user_experience)
      return user_settings
@@ -401,7 +401,7 @@ Now that we have the user experience field added to all the models, we can updat
              user_email_preferences.can_receive_subscription_email),
          'subscription_list': subscription_list
      })
-   + python_utils.PRINT(self.values)
+   + print(self.values)
      self.render_json(self.values)
    ```
 

--- a/Lint-Checks.md
+++ b/Lint-Checks.md
@@ -45,10 +45,10 @@ We use linters to check our code for common errors or bad patterns. The Oppia li
    python -m scripts.linters.run_lint_checks --files {{file paths}}
    ```
 
-   Separate file paths with spaces. For example, to lint `scripts/start.py` and `python_utils.py`, you could run this:
+   Separate file paths with spaces. For example, to lint `scripts/start.py` and `servers.py`, you could run this:
 
    ```console
-   python -m scripts.linters.run_lint_checks --files scripts/start.py python_utils.py
+   python -m scripts.linters.run_lint_checks --files scripts/start.py servers.py
    ```
 
 4. To lint files in verbose mode, add the `--verbose` flag like this:


### PR DESCRIPTION
## **Changes Following [#13935](https://github.com/oppia/oppia/issues/13935)**

In response to [#13935](https://github.com/oppia/oppia/issues/13935), several misleading mentions and incorrect warnings were removed from the wiki. These included:

- **Removal of `python_utils` mentions**: The previous examples using on `python_utils.OBJECT` and other utility functions has been updated. I’ve replaced them with standard Python constructs and best practices.
- **Fixing the incorrect warning about `str` function**: Some parts of the code were erroneously issuing warnings regarding the use of the `str()` function. This warning was removed as `str()` is the correct and accepted way to convert objects to strings in Python 3.

### **Key Changes:**
- **Removed references to `python_utils.OBJECT`** in class definitions, replacing them with standard Python class definitions.
- **Fixed the incorrect warning about using `str()`**: The previous message warning against using `str()` was incorrect, as `str()` is the appropriate way to convert to strings in Python 3.

These updates help modernize the wiki, making it more in line with the new Oppia standard.
