### PR TITLE
Fixed Issue # 459 - Removed references to Datastore error

### DIFF
--- a/Backend-tests.md
+++ b/Backend-tests.md
@@ -224,8 +224,6 @@ Ran 326 tests in 47 test classes.
 
 You can find more information about the exact errors by scrolling up and looking through the error log for tests marked `FAILED` (indicating that an assertion in the test failed) and `ERROR` (indicating that an exception was raised by the test).
 
-Note that you might see a bunch of lines that just contain `[datastore]`. While annoying, this is normal. We just haven't figured out how to get rid of them yet. You can follow [#14239](https://github.com/oppia/oppia/issues/14239) to track our progress in fixing this.
-
 ### Coverage reports
 
 #### Overall coverage


### PR DESCRIPTION
Removing reference to datastore error when running background tests. No longer an error, removing to improve clarity, conciseness, and avoid confusion.