### PR TITLE
Updated steps for locally testing state migrations

### DIFF
--- a/Writing-state-migrations.md
+++ b/Writing-state-migrations.md
@@ -38,7 +38,7 @@ If you find new test files where changes needed to be required, try updating the
 - Start the server and go to the admin page.
 - Load all demo exploration.
 - Create a new exploration, make some changes and save them.
-- Checkout the feature branch which contains state migration.
+- In a new terminal window, checkout the feature branch which contains state migration. The changed files will be detected in the server logs.
 - Go to 0.0.0.0:8000 and flush existing Memcache from the Memcache tab.
 - Go to the admin page and assign yourself the role of "release coordinator".
 - Go to the Misc tab of /release-coordinator page and flush the cache.

--- a/Writing-state-migrations.md
+++ b/Writing-state-migrations.md
@@ -45,5 +45,5 @@ If you find new test files where changes needed to be required, try updating the
 - Run `AuditExplorationMigrationJob` and wait for the job to get completed. This job will not make any changes to the exploration as this is simply an audit job. We run this job before the actual migration job so that in case anything fails we do not make changes to the datastore. Please make sure the job should be successful without any errors before moving forward.
 - Run `MigrateExplorationJob` and wait for the job to get completed. This will make changes to exploration.
 - Check the output of the job and post the screen-shot in your PR.
-- Go to the exploration you have created lately, check whether it's working as expected.
+- Go to the exploration you have created lately, check whether it's working as expected. To check the local datastore, refer to [Debugging datastore locally](https://github.com/oppia/oppia/wiki/Debugging-datastore-locally).
 - Check demo exploration (note demo exploration ids are 0, 1, 2, etc.)


### PR DESCRIPTION
Included link to debugging datastore doc and added clarification for switching to a different branch with the local server running.

Reason for changes:
- When I was working on https://github.com/oppia/oppia/pull/23382, the step 'Checkout the feature branch which contains state migration.' was a bit ambiguous and it took me a few tries to realise that I had to switch to a different branch in another terminal window and that the changes would automatically be detected.
- I think it would be beneficial to mention how to access the local datastore on this page as it makes validating and testing the migration easier, and it helped me figure out what was wrong with my initial migration approach.