### PR TITLE
Updated the link of contributor dashboard admin page

### DIFF
--- a/How-To-Load-Data.md
+++ b/How-To-Load-Data.md
@@ -18,7 +18,7 @@
 2. Navigate to the Admin page.
 3. Click the Roles tab.
 4. In the Role editor, enter the admin username (“a”). Click Add Role, and add both the “Curriculum Admin” role and “Question Admin” role.
-5. Go to http://localhost:8181/contributor-dashboard-admin and give submit question rights and review questions rights to your current username
+5. Go to http://localhost:8181/contributor-admin-dashboard and give submit question rights and review questions rights to your current username
 6. Navigate back to the Admin page and navigate to the Activities tab. Click Load Data under Load dummy new structures data.
 7. For the question opportunities to be valid, their corresponding topics must be part of a classroom topic. Navigate to the Config tab. Click Add element under [topic_id] (in the “The details for each classroom page.” section) and enter the topic id for the new topics that were created. (You can find a topic’s ID in its page URL from the Topic and Skills Dashboard). Make sure to click save at the bottom of the config page.
 8. To enable the “Submit Question” tab for your user, make sure your signed in user is allowlisted for submitting question suggestions.

--- a/How-to-access-Oppia-webpages.md
+++ b/How-to-access-Oppia-webpages.md
@@ -435,7 +435,7 @@ The contributor dashboard page allows users to translate existing explorations i
 
 1. Log in as a super-admin and assign to your user the "Question admin" role.
 
-2. Navigate to http://localhost:8181/contributor-dashboard-admin.
+2. Navigate to http://localhost:8181/contributor-admin-dashboard.
 
 ## User Documentation
 


### PR DESCRIPTION
Updated the Link of Contributor dashboard admin page :``` http://localhost:8181/contributor-admin-dashboard```

While testing issues related to suggesting questions, I needed access to the Contributor Admin Dashboard. I noticed that the wiki still pointed to the old route, which could be confusing for new contributors trying to access it.

This PR updates the link to the correct route: ```http://localhost:8181/contributor-admin-dashboard```

The change is meant to make it easier for contributors to find the right page and avoid unnecessary confusion.