### PR TITLE
Deprecate installing Oppia under Docker

### DIFF
--- a/Installing-Oppia-using-Docker.md
+++ b/Installing-Oppia-using-Docker.md
@@ -1,5 +1,8 @@
 This guide provides step-by-step instructions for installing Oppia using Docker. Docker simplifies the installation process and ensures a consistent environment across different systems, making it easier to set up and run Oppia.
+
 If you get stuck somewhere and need help, please refer to our [[Getting Help Page|Get-help]].
+
+**Warning:** Installing Oppia under Docker is no longer supported. These instructions are preserved here for future reference, but we do not recommend installing under Docker.
 
 ## Table of Contents
 

--- a/Installing-Oppia.md
+++ b/Installing-Oppia.md
@@ -26,7 +26,11 @@ To install Oppia, follow these instructions:
 * [[Windows|Installing-Oppia-(Windows;-Python-3)]]
 
 ## Installation using Docker
+
+**Warning:** Installing Oppia under Docker is no longer supported. These instructions are preserved here for future reference, but we do not recommend installing under Docker. If you currently run Oppia under Docker, we recommend migrating to the Python setup (above).
+
 To install Oppia using Docker, follow these instructions:
+
 * [[Oppia Docker Setup|Installing-Oppia-using-Docker]]
 
 If you run into any problems during installation, please read [[these notes|Issues-with-installation]] and the [[Troubleshooting page|Troubleshooting]].


### PR DESCRIPTION
There are a number of issues with installing Oppia under Docker (e.g. [#23631](https://github.com/oppia/oppia/discussions/23631), [#23605](https://github.com/oppia/oppia/discussions/23605)), and since we no longer have any active developers using the Docker installation (according to responses to an email to all developers), we are struggling to keep it maintained.

We originally planned to develop exclusively using the Docker installation so that developer environments would be kept consistent, but this ended up being infeasible because for many developers, the overhead of running Docker prevented their systems from running the development server locally. Without this consistency advantage, there isn't much of an advantage to installing under Docker, so maintaining a parallel installation path isn't worthwhile. Note that there are security benefits to sandboxing the development server inside Docker, but since this sandbox would be irrelevant in production, we'd rather devote effort to making Oppia secure both in development and in production. Worried developers can always run the development server inside a virtual machine for similar sandboxing protections.