### PR TITLE
Add --skip-install flag to documentation

### DIFF
--- a/Backend-tests.md
+++ b/Backend-tests.md
@@ -217,6 +217,18 @@ Docker:
 make run_tests.backend PYTHON_ARGS="--skip-install"
 ```
 
+You can also combine this flag with the ones mentioned above. For example, you can use it with the `--test-targets` flag for even faster runs like this:
+
+Python:
+```console
+python -m scripts.run_backend_tests --test_targets=core.controllers.editor_test --skip-install
+```
+
+Docker:
+```console
+make run_tests.backend PYTHON_ARGS="--test_targets=core.controllers.editor_test --skip-install"
+```
+
 Note that this skips reinstalling the required libraries, so remember to run the tests without this flag every once in a while to keep them up to date.
 
 ### Identifying whether the tests passed

--- a/Backend-tests.md
+++ b/Backend-tests.md
@@ -205,6 +205,20 @@ make run_tests.backend PYTHON_ARGS="--help"
 
 Note that while the tests are running, you may see the word `ERROR` show up in the test logs. This does not necessarily mean that an error has occurred; it happens because some tests actually expect an error to be raised.
 
+If you want to speed up subsequent runs of the tests, use `--skip-install` like this:
+
+Python:
+```console
+python -m scripts.run_backend_tests --skip-install
+```
+
+Docker:
+```console
+make run_tests.backend PYTHON_ARGS="--skip-install"
+```
+
+Note that this skips reinstalling the required libraries, so remember to run the tests without this flag every once in a while to keep them up to date.
+
 ### Identifying whether the tests passed
 
 The tests pass if, at the end of the test output, you see the message:


### PR DESCRIPTION
Reason for change:
- When I was working on https://github.com/oppia/oppia/pull/23382, I noticed that the tests were regenerating `requirements.txt` and reinstalling the same libraries on every run. This is inefficient, and the code for the backend-tests script contains a flag ('--skip-install') to speed up this process. I believe it would be beneficial to add information about this flag to the documentation as it would help speed up this process for other developers as well.