### PR TITLE
docs: update collection/exploration docs 

### DIFF
--- a/How-to-access-Oppia-webpages.md
+++ b/How-to-access-Oppia-webpages.md
@@ -22,14 +22,13 @@
   * [Landing pages](#landing-pages)
   * [Thanks page](#thanks-page)
   * [Terms page](#terms-page)
-* [Collection pages](#collection-pages)
-  * [Collection editor page](#collection-editor-page)
-  * [Collection player page](#collection-player-page)
-* [Exploration pages](#exploration-pages)
-  * [Community library page](#community-library-page)
+* [Collection & Exploration pages](#collection--exploration-pages)
   * [Creator dashboard page](#creator-dashboard-page)
+  * [Collection editor page](#collection-editor-page)
   * [Exploration editor page](#exploration-editor-page)
+  * [Collection player page](#collection-player-page)
   * [Exploration player page](#exploration-player-page)
+  * [Community library page](#community-library-page)
 * [Topics and skills pages](#topics-and-skills-pages)
   * [Topics and skills dashboard page](#topics-and-skills-dashboard-page)
   * [Topic editor (including preview tab)](#topic-editor-including-preview-tab)
@@ -260,23 +259,18 @@ The Terms page addresses the terms and conditions of Oppia.
 
 1. Go to http://localhost:8181/terms.
 
-## Collection pages
+## Collection & Exploration pages
 
 ### Collection editor page
 
-The Collection editor page allows users to create collections, which group explorations together. The collection editor page can only be accessed by users with the "collection editor" role.
+The Collection Editor allows you to create collections that group explorations together.
 
-1. Log in as a super-admin and assign yourself the "collection editor" role.
-
-2. Navigate to the splash page (http://localhost:8181/splash).
-
-3. Click on the "Create" button in the top navigation bar.
-
-   ![Create Button](https://user-images.githubusercontent.com/16653571/41504441-a7f60512-720c-11e8-85c2-8fee5f55a42c.png)
-
-4. Select "Create Collection."
-
-   ![CREATE COLLECTION button](https://user-images.githubusercontent.com/16653571/41504483-d946fd3c-720d-11e8-997d-943cd8703e57.png)
+- Permissions: Requires the "collection editor" role (assign via Admin → ROLES).
+- Access path:
+  1. Log in as a super-admin and assign yourself the "collection editor" role.
+  2. Navigate to the Creator Dashboard (http://localhost:8181/creator-dashboard).
+  3. Click "Create New Collection" to open the Collection Editor.
+- Typical workflow: Add explorations to the collection, reorder them, provide metadata, and publish the collection.
 
 ### Collection player page
 
@@ -318,11 +312,15 @@ The creator dashboard page allows users to view all explorations they have creat
 
 ### Exploration editor page
 
-The exploration editor page allows users to create explorations, or lessons, in Oppia.
+### Exploration editor page
 
-1. Log in.
+The Exploration Editor is where creators build interactive lessons using cards, interactions, and responses.
 
-2. Click the "Create" button on the top right to open the exploration editor.
+- Access path:
+  1. Log in and navigate to the Creator Dashboard (http://localhost:8181/creator-dashboard).
+  2. Click "Create New Exploration" (or open any existing draft) to launch the editor.
+- Typical workflow: Author cards, configure interactions and feedback, preview, then publish.
+
 
 ### Exploration player page
 

--- a/How-to-access-Oppia-webpages.md
+++ b/How-to-access-Oppia-webpages.md
@@ -22,7 +22,7 @@
   * [Landing pages](#landing-pages)
   * [Thanks page](#thanks-page)
   * [Terms page](#terms-page)
-* [Collection & Exploration pages](#collection--exploration-pages)
+* [Collection & Exploration pages](#collection-exploration-pages)
   * [Creator dashboard page](#creator-dashboard-page)
   * [Collection editor page](#collection-editor-page)
   * [Exploration editor page](#exploration-editor-page)
@@ -261,6 +261,14 @@ The Terms page addresses the terms and conditions of Oppia.
 
 ## Collection & Exploration pages
 
+### Creator dashboard page
+
+The creator dashboard page allows users to view all explorations they have created, or are currently creating.
+
+1. Log in.
+
+2. Navigate to the creator dashboard page at http://localhost:8181/creator-dashboard.
+
 ### Collection editor page
 
 The Collection Editor allows you to create collections that group explorations together.
@@ -271,6 +279,15 @@ The Collection Editor allows you to create collections that group explorations t
   2. Navigate to the Creator Dashboard (http://localhost:8181/creator-dashboard).
   3. Click "Create New Collection" to open the Collection Editor.
 - Typical workflow: Add explorations to the collection, reorder them, provide metadata, and publish the collection.
+
+### Exploration editor page
+
+The Exploration Editor is where creators build interactive lessons using cards, interactions, and responses.
+
+- Access path:
+  1. Log in and navigate to the Creator Dashboard (http://localhost:8181/creator-dashboard).
+  2. Click "Create New Exploration" (or open any existing draft) to launch the editor.
+- Typical workflow: Author cards, configure interactions and feedback, preview, then publish.
 
 ### Collection player page
 
@@ -286,7 +303,17 @@ The collection player page allows users to explore collections in Oppia.
 
 4. Click on the card titled "Introduction to collections in Oppia."
 
-## Exploration pages
+### Exploration player page
+
+The exploration player page allows users to play explorations in Oppia.
+
+1. Navigate to http://localhost:8181/community-library.
+
+2. Enter "fractions" into the search bar.
+
+3. Click on the exploration titled "Fractions 1 - What is the Fraction?"
+
+The exploration will launch in a new tab, where you will see the first card. As you progress through the exploration, you will see subsequent cards, each of which has some content (text, images, videos, or other rich text components). Some will also have interactions like multiple choice questions. A user's answer to these interactions are called "responses."
 
 ### Community library page
 
@@ -302,37 +329,6 @@ The library page has a search bar that lets you search for explorations:
 
 You can search the library, which consists of all of Oppia's explorations, by entering text, and you can filter by category (also called subject) and language.
 
-### Creator dashboard page
-
-The creator dashboard page allows users to view all explorations they have created, or are currently creating.
-
-1. Log in.
-
-2. Navigate to the creator dashboard page at http://localhost:8181/creator-dashboard.
-
-### Exploration editor page
-
-### Exploration editor page
-
-The Exploration Editor is where creators build interactive lessons using cards, interactions, and responses.
-
-- Access path:
-  1. Log in and navigate to the Creator Dashboard (http://localhost:8181/creator-dashboard).
-  2. Click "Create New Exploration" (or open any existing draft) to launch the editor.
-- Typical workflow: Author cards, configure interactions and feedback, preview, then publish.
-
-
-### Exploration player page
-
-The exploration player page allows users to play explorations in Oppia.
-
-1. Navigate to http://localhost:8181/community-library.
-
-2. Enter "fractions" into the search bar.
-
-3. Click on the exploration titled "Fractions 1 - What is the Fraction?"
-
-The exploration will launch in a new tab, where you will see the first card. As you progress through the exploration, you will see subsequent cards, each of which has some content (text, images, videos, or other rich text components). Some will also have interactions like multiple choice questions. A user's answer to these interactions are called "responses."
 
 ## Topics and skills pages
 


### PR DESCRIPTION
This PR brings the Oppia developer documentation up to date with the current UI and contributor workflow.

Changes included:

Combined the old “Collection pages” and “Exploration pages” sections into a single Collection & Exploration pages section for clarity.

Updated the instructions for accessing the Collection Editor and Exploration Editor so they now reflect the Creator Dashboard flow.

Cleaned up the Table of Contents by fixing anchors, adjusting the order, and removing a duplicate heading for the Exploration Editor.

Double‑checked that the player pages and Community Library instructions are still accurate and didn’t require changes.

Why these changes matter:

Keeps the documentation aligned with the current Oppia UI.

Makes it easier for new contributors to follow the right steps without confusion.

Reduces redundancy and improves the overall readability of the docs.

Fixes issue : #480