### PR TITLE
Clarify virtual environment setup instructions (Points 7 & 8)

### DIFF
--- a/Installing-Oppia-(Linux;-Python-3).md
+++ b/Installing-Oppia-(Linux;-Python-3).md
@@ -167,7 +167,11 @@ exec "$SHELL"
    > [!WARNING]
    > Be careful with using graphical editors like Notepad in Windows. These can add carriage returns (`\r`) that confuse our Linux-based development tools. Instead, we recommend using editors designed for programming or command-line text editors.
 
-7. Add new file called `.direnvrc` into your home (`~`) folder with this content:
+7. Add new file called `.direnvrc` into your home (`~`) directory (also called your user’s root folder, e.g., `/home/your-username/`). You can also use the tilde (`~`) shorthand to refer to this directory in commands. To verify that you are in the correct directory, you can run:
+```bash
+pwd
+```
+This should print the path to your home directory. Then add the following content to `.direnvrc`:
    ```bash
    use_python() {
      local python_root=$(pyenv root)/versions/$1
@@ -184,8 +188,7 @@ exec "$SHELL"
    > [!WARNING]
    > Be careful with using graphical editors like Notepad in Windows. These can add carriage returns (`\r`) that confuse our Linux-based development tools. Instead, we recommend using editors designed for programming or command-line text editors.
 
-8. Create a virtual environment for oppia by adding file named `.envrc` into the parent folder of the oppia repository
-   with this content:
+8. Create a virtual environment for oppia by adding file named `.envrc` into the root folder containing the oppia repository with this content:
 
     ```console
     use python 3.10.16

--- a/Installing-Oppia-(Linux;-Python-3).md
+++ b/Installing-Oppia-(Linux;-Python-3).md
@@ -188,7 +188,7 @@ This should print the path to your home directory. Then add the following conten
    > [!WARNING]
    > Be careful with using graphical editors like Notepad in Windows. These can add carriage returns (`\r`) that confuse our Linux-based development tools. Instead, we recommend using editors designed for programming or command-line text editors.
 
-8. Create a virtual environment for oppia by adding file named `.envrc` into the root folder containing the oppia repository with this content:
+8. Create a virtual environment for oppia by adding file named `.envrc` into the oppia root folder. with this content:
 
     ```console
     use python 3.10.16

--- a/Installing-Oppia-(Linux;-Python-3).md
+++ b/Installing-Oppia-(Linux;-Python-3).md
@@ -188,7 +188,7 @@ This should print the path to your home directory. Then add the following conten
    > [!WARNING]
    > Be careful with using graphical editors like Notepad in Windows. These can add carriage returns (`\r`) that confuse our Linux-based development tools. Instead, we recommend using editors designed for programming or command-line text editors.
 
-8. Create a virtual environment for oppia by adding file named `.envrc` into the oppia root folder. with this content:
+8. Create a virtual environment for oppia by adding file named `.envrc` into the oppia root folder with this content:
 
     ```console
     use python 3.10.16


### PR DESCRIPTION
PR Description

Background:
In the Oppia installation docs, the instructions for setting up the virtual environment (points 7 and 8) caused some confusion for beginners:

Point 7: Mentioned adding the .direnvrc file to the “home directory,” but did not explain how users could verify they were in the correct directory.

Point 8: The wording around creating a virtual environment was a bit technical and could be simplified.

Changes Made:

Point 7:

Clarified that the .direnvrc file should be added to the user’s home directory (e.g., /home/your-username/).

Introduced the commonly used tilde (~) shorthand to refer to the home directory.

Added a suggestion to run pwd to verify the current directory before creating the file.

Point 8:

Reworded instructions to be more beginner-friendly, explaining in simpler language how to create the .envrc file in the root folder of the cloned Oppia repository.

Example of updated text:

“Add a new file called .direnvrc into your user’s home (~) directory (e.g., /home/your-username/). You can run pwd to verify that you are in the correct directory. Then add the following content …”

“Create a virtual environment for Oppia by adding a file named .envrc into the root folder containing the Oppia repository with this content: use python 3.10.16. Then run direnv allow. Now whenever you are within the oppia folder, the virtual environment will be active.”

Impact:
These changes improve clarity and reduce confusion for first-time users setting up Oppia on their local machine.

Related Issue: #465