### PR TITLE
Doc: Add troubleshooting note for Python versioning in legacy bisection

### DIFF
--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -23,6 +23,7 @@ Here are some general troubleshooting tips for Oppia. The platform specific tips
 - [No Such File or Directory: Google Cloud SDK](#no-such-file-or-directory-google-cloud-sdk)
 - [No module named '\_sqlite3'](#no-module-named-_sqlite3)
 - [Problems Cloning from GitHub](#problems-cloning-from-github)
+- [Troubleshooting Legacy Bisection (Python Versioning)](#troubleshooting-legacy-bisection-python-versioning)
 - [Certificate Verify Failed](#certificate-verify-failed)
 - [No Module Named Scripts](#no-module-named-scripts)
 - [Invalid Syntax](#invalid-syntax)
@@ -177,6 +178,18 @@ If you have issues cloning the GitHub repository, make sure of the following:
 1. That you’ve already [forked](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) the Oppia repository
 2. That you’re making sure to [clone](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo#keep-your-fork-synced) from your own fork (making sure to replace `YOUR_USERNAME` in `git clone https://github.com/YOUR-USERNAME/oppia.git` with your GitHub username)
 3. If you have two-factor authentication (which you should), that you’re typing in your [access token](https://webkul.com/blog/github-push-with-two-factor-authentication/) as your password when prompted (rather than your GitHub password).
+
+### Troubleshooting Legacy Bisection (Python Versioning)
+
+When using `git bisect` to track down bugs in older commits (specifically those before April 2024), you might encounter fatal installation errors. This usually happens because legacy dependencies require **Python 3.8.15**, while modern developer environments typically run **Python 3.10** or higher.
+
+* **The Issue:** Older versions of libraries like `grpcio` or `protobuf` will fail to compile or install on newer Python versions (3.10+).
+* **The Recommended Approach:** If you must bisect into legacy territory, it is highly recommended to use a version manager like `pyenv` to match the Python 3.8 environment required by those specific commits. This ensures the environment matches the requirements of the commit being tested and has been noted to resolve installation failures for older library versions.
+    bash
+    pyenv install 3.8.15
+    pyenv local 3.8.15
+   
+* **Note:** This ensures that the environment matches the requirements of the specific commit being tested.
 
 ### Certificate Verify Failed
 

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -23,7 +23,7 @@ Here are some general troubleshooting tips for Oppia. The platform specific tips
 - [No Such File or Directory: Google Cloud SDK](#no-such-file-or-directory-google-cloud-sdk)
 - [No module named '\_sqlite3'](#no-module-named-_sqlite3)
 - [Problems Cloning from GitHub](#problems-cloning-from-github)
-- [Troubleshooting Legacy Bisection (Python Versioning)](#troubleshooting-legacy-bisection-python-versioning)
+- [Troubleshooting legacy bisection (Python versioning)](#troubleshooting-legacy-bisection-python-versioning)
 - [Certificate Verify Failed](#certificate-verify-failed)
 - [No Module Named Scripts](#no-module-named-scripts)
 - [Invalid Syntax](#invalid-syntax)
@@ -179,17 +179,16 @@ If you have issues cloning the GitHub repository, make sure of the following:
 2. That you’re making sure to [clone](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo#keep-your-fork-synced) from your own fork (making sure to replace `YOUR_USERNAME` in `git clone https://github.com/YOUR-USERNAME/oppia.git` with your GitHub username)
 3. If you have two-factor authentication (which you should), that you’re typing in your [access token](https://webkul.com/blog/github-push-with-two-factor-authentication/) as your password when prompted (rather than your GitHub password).
 
-### Troubleshooting Legacy Bisection (Python Versioning)
+### Troubleshooting legacy bisection (Python versioning)
 
 When using `git bisect` to track down bugs in older commits (specifically those before April 2024), you might encounter fatal installation errors. This usually happens because legacy dependencies require **Python 3.8.15**, while modern developer environments typically run **Python 3.10** or higher.
 
 * **The Issue:** Older versions of libraries like `grpcio` or `protobuf` will fail to compile or install on newer Python versions (3.10+).
 * **The Recommended Approach:** If you must bisect into legacy territory, it is highly recommended to use a version manager like `pyenv` to match the Python 3.8 environment required by those specific commits. This ensures the environment matches the requirements of the commit being tested and has been noted to resolve installation failures for older library versions.
-    bash
+    ```bash
     pyenv install 3.8.15
     pyenv local 3.8.15
-   
-* **Note:** This ensures that the environment matches the requirements of the specific commit being tested.
+    ```
 
 ### Certificate Verify Failed
 


### PR DESCRIPTION
## Overview
This PR adds a troubleshooting entry for Python versioning issues encountered during legacy bisection.

## Reasoning
While attempting to bisect back to pre-April 2024 commits, I identified a recurring installation failure caused by a mismatch between modern Python environments (3.10+) and legacy dependency requirements (Python 3.8.15). Adding this note helps new contributors identify this environmental blocker quickly and provides the standard pyenv workaround to maintain environment parity during debugging.