### PR TITLE
Add standardized PR template for docs repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Overview
+Briefly describe what this PR does.
+
+## Linked Issue
+This PR fixes #[fill_in_number_here] or fixes part of #[fill_in_number_here].
+
+## Changes Made
+- 
+- 
+- 
+
+## Testing
+- [ ] Verified hyperlinks work as expected
+- [ ] Checked linters pass locally
+- [ ] Confirmed instructions/steps added are accurate and work as expected
+
+## Notes for Reviewers
+Anything specific reviewers should focus on.


### PR DESCRIPTION
 Overview
This PR adds a pull request template to the web developer docs as it did not have one.

## Linked Issue
This PR fixes #N/A, it was discussed with @HardikGoyal2003 https://github.com/oppia/oppia/discussions/25965#discussion-9959953

## Changes Made
- Added a new default GitHub PR template file: .github/pull_request_template.md
- Standardized required sections in the template such as overview, linked issue, changes made, testing and notes for reviewers

## Testing
- [x] Verified hyperlinks work as expected
- [x] Checked linters pass locally
- [x] Confirmed instructions/steps added are accurate and work as expected

## Notes for Reviewers
Note that it is slightly different from the proposed template as originally I had proposed `Fixes#` but it did not take into account `Fixes part of #` so the latter has been added to address the same.